### PR TITLE
Fix: Node12 Buffer Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ var PRESET = [
 
 instance.prototype.sendVISCACommand = function(payload) {
 	var self = this;
-	var buf = new Buffer(32);
+	var buf = Buffer.from(32);
 
 		// 0x01 0x00 = VISCA Command
 		buf[0] = 0x01;
@@ -187,7 +187,7 @@ instance.prototype.sendVISCACommand = function(payload) {
 
 instance.prototype.sendVISCACommand = function(payload, counter) {
 	var self = this;
-	var buf = new Buffer(32);
+	var buf = Buffer.from(32);
 
 		// 0x01 0x00 = VISCA Command
 		buf[0] = 0x01;
@@ -306,7 +306,7 @@ instance.prototype.sendResponse = function(data) {
 
 instance.prototype.sendControlCommand = function(payload) {
 	var self = this;
-	var buf = new Buffer(32);
+	var buf = Buffer.from(32);
 
 	// 0x01 0x00 = VISCA Command
 	buf[0] = 0x02;
@@ -1218,7 +1218,7 @@ instance.prototype.action = function(action) {
 
 		case 'custom':
 			var hexData = opt.custom.replace(/\s+/g, '');
-			var tempBuffer = new Buffer(hexData, 'hex');
+			var tempBuffer = Buffer.from(hexData, 'hex');
 			cmd = tempBuffer.toString('binary');
 			if ((tempBuffer[0] & 0xF0) === 0x80) {
 				self.sendVISCACommand(cmd);

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ var PRESET = [
 
 instance.prototype.sendVISCACommand = function(payload) {
 	var self = this;
-	var buf = Buffer.from(32);
+	var buf = Buffer.alloc(32);
 
 		// 0x01 0x00 = VISCA Command
 		buf[0] = 0x01;
@@ -187,7 +187,7 @@ instance.prototype.sendVISCACommand = function(payload) {
 
 instance.prototype.sendVISCACommand = function(payload, counter) {
 	var self = this;
-	var buf = Buffer.from(32);
+	var buf = Buffer.alloc(32);
 
 		// 0x01 0x00 = VISCA Command
 		buf[0] = 0x01;
@@ -306,7 +306,7 @@ instance.prototype.sendResponse = function(data) {
 
 instance.prototype.sendControlCommand = function(payload) {
 	var self = this;
-	var buf = Buffer.from(32);
+	var buf = Buffer.alloc(32);
 
 	// 0x01 0x00 = VISCA Command
 	buf[0] = 0x02;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "birddog-visca",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Protocol",


### PR DESCRIPTION
Updated uses of the deprecated `new Buffer()` to the Node12 compliant functions `Buffer.from()` and `Buffer.alloc()`.

Changes made following the guidelines of Variant 1 of the NodeJS Buffer constructor deprecation guide  https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/