### PR TITLE
Add KBD as a special kind of Camera model

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -5453,17 +5453,13 @@ export function getActions() {
 			},
 		}
 	}
-	return Object.fromEntries(Object.entries(actions).sort(sortByAction))
-}
-
-export function getKBDActions() {
-	return {
-		active_camera: {
+	if (MODEL_ACTIONS?.active_camera) {
+		actions['active_camera'] = {
 			name: 'Active Camera',
 			options: [
 				{
 					type: 'number',
-					label: `Camera Channel`,
+					label: `Camera Number`,
 					id: 'val',
 					default: 1,
 					min: 1,
@@ -5471,9 +5467,9 @@ export function getKBDActions() {
 				},
 			],
 			callback: (action) => {
-				let command = `cgi-bin/connTheDev.cgi?channel=${action.options.val}`
-				this.sendKBDCommand(command, 'GET')
+				this.sendCommand(`SelectCam?camera=${action.options.val}`, 'POST', {})
 			},
-		},
+		}
 	}
+	return Object.fromEntries(Object.entries(actions).sort(sortByAction))
 }

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -3496,6 +3496,31 @@ export function getFeedbacks() {
 		}
 	}
 
+	if (MODEL_ACTIONS?.active_camera) {
+		feedbacks.active_camera = {
+			type: 'boolean',
+			name: "Active Camera",
+			description: "If the camera matches the current KBD camera, change the style of the button.",
+			defaultStyle: {
+				color: ColorBlack,
+				bgcolor: ColorGreen,
+			},
+			options: [
+				{
+					type: 'number',
+					label: 'Camera Number',
+					id: 'val',
+					default: 1,
+					min: 1,
+					max: 256,
+				},
+			],
+			callback: (feedback) => {
+				return this.camera?.active_camera == feedback.options.val
+			},
+		}
+	}
+
 	// Other Feedback
 
 	this.setFeedbackDefinitions(feedbacks)

--- a/models.js
+++ b/models.js
@@ -105,6 +105,9 @@ export const MODEL_QUERIES = {
 
 	//Scope Settings
 	birddogscope: { camera: ['All'], firmware: ['5'] },
+
+	//KBB Settings
+	active_camera: { camera: ['KBD'], firmware: ['0'] }
 }
 
 export const MODEL_SPECS = {
@@ -3490,6 +3493,22 @@ export const MODEL_SPECS = {
 		api_variable: ['vid_str_name'],
 		variableId: 'vid_str_name',
 		name: `Dashboard - NDI Video Stream Name`,
+	},
+
+	// KBD
+	active_camera: {
+		camera: ['KBD'],
+		firmware: ['0'],
+		store_state: true,
+		api_endpoint: ['SelectCam'],
+		api_variable: ['camera'],
+		variableId: 'active_camera',
+		action: [
+			{
+				camera: ['KBD'],
+			},
+		],
+		name: "KBD - Active Camera"
 	},
 
 	// Other Actions

--- a/presets.js
+++ b/presets.js
@@ -7488,5 +7488,46 @@ export function getPresets() {
 		}
 	}
 
+	if (MODEL_ACTIONS?.active_camera) {
+		let cam
+		for (cam = 1; cam < 6; cam++) {
+			presets[`activeCameraPset${cam}`] = {
+				type: 'button',
+				category: 'KBD_controller',
+				name: 'Set Active Camera',
+				options: {},
+				style: {
+					text: 'Preset Camera ' + parseInt(cam),
+					size: 'auto',
+					color: ColorWhite,
+					bgcolor: ColorBlack,
+				},
+				steps: [
+					{
+						down: [
+							{
+								actionId: 'active_camera',
+								options: {
+									val: parseInt(cam),
+								},
+							},
+						],
+						up: [],
+					},
+				],
+				feedbacks: [
+					{
+						feedbackId: 'active_camera',
+						options: { val: parseInt(cam) },
+						style: {
+							color: ColorBlack,
+							bgcolor: ColorGreen,
+						},
+					},
+				],
+			}
+		}
+	}
+
 	return presets
 }

--- a/utils.js
+++ b/utils.js
@@ -97,7 +97,7 @@ export function getModelVariables(array, FW, model) {
 	let filteredArray = tempArray.filter(
 		(array) =>
 			// filter array based on: All cameras or Model matches, and FW matches & has 'variable_name' object
-			(array[1].camera.includes(model) || array[1].camera.includes('All')) &&
+			(array[1].camera.includes(model) || (array[1].camera.includes('All') && (model != "KBD"))) &&
 			array[1].firmware.includes(FW) &&
 			array[1]?.variableId,
 	)
@@ -118,7 +118,7 @@ export function getModelActions(array, FW, model) {
 	let filteredArray = tempArray.filter(
 		(array) =>
 			// filter array based on: All cameras or Model matches, and FW matches & has 'action' object
-			(array[1].camera.includes(model) || array[1].camera.includes('All')) &&
+			(array[1].camera.includes(model) || (array[1].camera.includes('All') && model != "KBD")) &&
 			array[1].firmware.includes(FW) &&
 			array[1]?.action,
 	)
@@ -137,7 +137,7 @@ export function getModelActionDetails(array, FW, model) {
 	let commonActions = array.filter((array) => array.camera.includes('common'))
 	let modelActions = array.filter(
 		// filter array based on: All cameras or Model matches, and if it contains a FW filed, then if FW matches
-		(array) => (array.camera.includes(model) || array.camera.includes('All')) && (array.firmware?.includes(FW) ?? true),
+		(array) => (array.camera.includes(model) || (array.camera.includes('All') && (model != "KBD"))) && (array.firmware?.includes(FW) ?? true),
 	)
 	return merge(commonActions[0]?.action, modelActions[0]?.action)
 }
@@ -146,7 +146,7 @@ export function getModelQueries(array, model, FW) {
 	let asArray = Object.entries(array)
 	return Object.fromEntries(
 		asArray.filter(
-			(item) => (item[1].camera.includes(model) || item[1].camera.includes('All')) && item[1].firmware.includes(FW),
+			(item) => (item[1].camera.includes(model) || (item[1].camera.includes('All') && (model != "KBD"))) && item[1].firmware.includes(FW),
 		),
 	)
 }

--- a/variables.js
+++ b/variables.js
@@ -823,5 +823,9 @@ export function updateVariables() {
 		updatedVariables.vid_str_name = this.camera.vid_str_name
 	}
 
+	if (MODEL_VARIABLES.some((variable) =>  variable.variableId === 'active_camera')) {
+		updatedVariables.active_camera = this.camera.active_camera
+	}
+
 	this.setVariableValues(updatedVariables)
 }


### PR DESCRIPTION
This adds model "KBD" to the possible list of cameras.

The KBD has a very restricted support for the API. Only `/SelectCam` is supported. In particular `/about` and `/version` are not supported so there are a couple of hacks in here to work-around this.

All searches for camera models as "All" have had to be modified to explicitly exclude "KDB". There is probably room for cleanup here but it works.

Functionality Added:

* Add Model "KBD"
* Add Action "Active Camera" to set the active camera on the joystick
* Add Feedback "Active Camera" to test the active camera
* Add Variable 'active_camera' with the value of the active camera
* Add Presets for setting/testing cameras 1-6

This resolves #169 
